### PR TITLE
`pclmulqdq`-based folding

### DIFF
--- a/include/CRC32.hpp
+++ b/include/CRC32.hpp
@@ -5,8 +5,84 @@
 #include <numeric>
 #include <span>
 
-#ifdef __AVX2__
-#include <immintrin.h>
+#ifdef __x86_64__
+#include <x86intrin.h>
+#endif
+
+#ifdef __PCLMUL__
+constexpr std::uint32_t BitReverse32(std::uint32_t Value)
+{
+	std::uint32_t Reversed = 0;
+	for( std::uint32_t BitIndex = 0u; BitIndex < 32u; ++BitIndex )
+	{
+		Reversed = (Reversed << 1u) + (Value & 0b1);
+		Value >>= 1u;
+	}
+	return Reversed;
+}
+
+// BitReverse(x^(shift) mod P(x) << 32) << 1
+constexpr std::uint64_t
+	KnConstant(std::uint32_t ByteShift, std::uint32_t Polynomial)
+{
+	std::uint32_t Remainder = 1u << 24;
+	for( std::size_t i = 5; i <= (ByteShift + 1); ++i )
+	{
+		for( std::int8_t BitIndex = 0; BitIndex < 8; ++BitIndex )
+		{
+			// Remainder is about to overflow, increment quotient
+			if( Remainder >> 31u )
+			{
+				Remainder <<= 1u;        // r *= x
+				Remainder ^= Polynomial; // r += poly
+			}
+			else
+			{
+				Remainder <<= 1u; // r *= 2
+			}
+		}
+	}
+	return static_cast<std::uint64_t>(BitReverse32(Remainder)) << 1;
+}
+
+// BitReverse(x^64 / P(x)) << 1
+constexpr std::uint64_t MuConstant(uint32_t Polynomial)
+{
+	std::uint32_t Remainder = 1u << 24;
+	std::uint32_t Quotient  = 0u;
+	for( std::size_t i = 5; i <= 9; ++i )
+	{
+		for( std::int8_t BitIndex = 0; BitIndex < 8; ++BitIndex )
+		{
+			Quotient <<= 1u; // q *= x
+			// Remainder is about to overflow, increment quotient
+			if( Remainder >> 31u )
+			{
+				Remainder <<= 1u;        // r *= x
+				Remainder ^= Polynomial; // + poly
+				Quotient |= 1u;          // + x^0
+			}
+			else
+			{
+				Remainder <<= 1u; // r *= 2
+			}
+		}
+	}
+	return (static_cast<std::uint64_t>(BitReverse32(Quotient)) << 1u) | 1;
+}
+
+#define POLY 0x1EDC6F41
+#define IEEEPOLY 0x04C11DB7
+
+// clang-format off
+static_assert(KnConstant(  64 + 4, IEEEPOLY) == 0x154442BD4);
+static_assert(KnConstant(  64 - 4, IEEEPOLY) == 0x1C6E41596);
+static_assert(KnConstant(  16 + 4, IEEEPOLY) == 0x1751997D0);
+static_assert(KnConstant(  16 - 4, IEEEPOLY) == 0x0ccaa009e);
+static_assert(KnConstant(       8, IEEEPOLY) == 0x163cd6124);
+static_assert(KnConstant(       4, IEEEPOLY) == 0x1db710640);
+static_assert(MuConstant(          IEEEPOLY) == 0x1F7011641);
+// clang-format on
 #endif
 
 namespace CRC


### PR DESCRIPTION
Initial implementation of `pclmulqdq`-based CRC32 folding based on the [2009 intel paper](https://www.intel.com/content/dam/www/public/us/en/documents/white-papers/fast-crc-computation-generic-polynomials-pclmulqdq-paper.pdf).