### PR TITLE
 a64: Use vector shift-insert for 64->32 truncate

### DIFF
--- a/source/CRC/CRC32-a64.cpp
+++ b/source/CRC/CRC32-a64.cpp
@@ -269,11 +269,11 @@ std::uint32_t CRC32_PMULL(std::span<const std::byte> Data, std::uint32_t CRC)
 	}
 
 	// Reduce 128 to 64
-	static const poly64x2_t Lo32Mask64 = vdupq_n_p64(0xFFFFFFFF);
+	static const uint64x2_t Zero = vdupq_n_u64(0);
 	{
 		const poly64x2_t MulHiLo = pmull_p64<1, 0>(CRCVec.val[0], K3K4);
 
-		const poly64x2_t Upper64 = vextq_s8(CRCVec.val[0], vdupq_n_s8(0), 8);
+		const poly64x2_t Upper64 = vextq_s8(CRCVec.val[0], Zero, 8);
 
 		CRCVec.val[0] = veorq_u64(Upper64, MulHiLo);
 
@@ -282,9 +282,8 @@ std::uint32_t CRC32_PMULL(std::span<const std::byte> Data, std::uint32_t CRC)
 			0ull,
 		};
 
-		const poly64x2_t Upper96 = vextq_s8(CRCVec.val[0], vdupq_n_s8(0), 4);
-
-		const poly64x2_t Trunc32 = vandq_u64(CRCVec.val[0], Lo32Mask64);
+		const poly64x2_t Upper96 = vextq_s8(CRCVec.val[0], Zero, 4);
+		const poly64x2_t Trunc32 = vsliq_n_u64(CRCVec.val[0], Zero, 32);
 
 		const poly64x2_t MulLo = pmull_p64<0, 0>(Trunc32, K5K0);
 
@@ -298,11 +297,11 @@ std::uint32_t CRC32_PMULL(std::span<const std::byte> Data, std::uint32_t CRC)
 			MuConstant(Polynomial),
 		};
 
-		poly64x2_t Trunc32 = vandq_u64(CRCVec.val[0], Lo32Mask64);
+		poly64x2_t Trunc32 = vsliq_n_u64(CRCVec.val[0], Zero, 32);
 
 		const poly64x2_t MulHiLo = pmull_p64<1, 0>(Trunc32, Poly);
 
-		Trunc32                = vandq_u64(MulHiLo, Lo32Mask64);
+		Trunc32                = vsliq_n_u64(MulHiLo, Zero, 32);
 		const poly64x2_t MulLo = pmull_p64<0, 0>(Trunc32, Poly);
 
 		CRCVec.val[0] = veorq_u64(CRCVec.val[0], MulLo);

--- a/source/CRC/CRC32-a64.cpp
+++ b/source/CRC/CRC32-a64.cpp
@@ -195,7 +195,8 @@ inline poly64x2_t
 template<std::uint32_t Polynomial>
 std::uint32_t CRC32_PMULL(std::span<const std::byte> Data, std::uint32_t CRC)
 {
-	poly64x2x4_t CRCVec = reinterpret_cast<const poly64x2x4_t*>(Data.data())[0];
+	poly64x2x4_t CRCVec
+		= vld1q_p64_x4(reinterpret_cast<const poly64_t*>(Data.data()));
 
 	Data = Data.subspan(64);
 
@@ -221,7 +222,7 @@ std::uint32_t CRC32_PMULL(std::span<const std::byte> Data, std::uint32_t CRC)
 		const poly64x2_t MulHi3 = pmull_p64<1, 1>(CRCVec.val[3], K1K2);
 
 		const poly64x2x4_t Load
-			= reinterpret_cast<const poly64x2x4_t*>(Data.data())[0];
+			= vld1q_p64_x4(reinterpret_cast<const poly64_t*>(Data.data()));
 
 		CRCVec.val[0] = eor3_p64(MulHi0, MulLo0, Load.val[0]);
 		CRCVec.val[1] = eor3_p64(MulHi1, MulLo1, Load.val[1]);
@@ -260,7 +261,7 @@ std::uint32_t CRC32_PMULL(std::span<const std::byte> Data, std::uint32_t CRC)
 	for( ; Data.size() >= 16; Data = Data.subspan(16) )
 	{
 		const poly64x2_t Load
-			= *reinterpret_cast<const poly64x2_t*>(Data.data());
+			= vld1q_p64(reinterpret_cast<const poly64_t*>(Data.data()));
 
 		const poly64x2_t MulLo = pmull_p64<0, 0>(CRCVec.val[0], K3K4);
 		const poly64x2_t MulHi = pmull_p64<1, 1>(CRCVec.val[0], K3K4);

--- a/source/CRC/CRC32-a64.cpp
+++ b/source/CRC/CRC32-a64.cpp
@@ -269,7 +269,7 @@ std::uint32_t CRC32_PMULL(std::span<const std::byte> Data, std::uint32_t CRC)
 	}
 
 	// Reduce 128 to 64
-	static const uint64x2_t Zero = vdupq_n_u64(0);
+	const uint64x2_t Zero = vdupq_n_u64(0);
 	{
 		const poly64x2_t MulHiLo = pmull_p64<1, 0>(CRCVec.val[0], K3K4);
 


### PR DESCRIPTION
Rather than having to keep around a `0xFFFFFFFFULL` mask, use the pre-existing `zero` register and a 32-bit shift-insert. This should generally reduce the number of needed registers and constants during the reduction-step.